### PR TITLE
Github Actions - Build and push to GCR

### DIFF
--- a/.github/workflows/docker-make-data.yml
+++ b/.github/workflows/docker-make-data.yml
@@ -1,4 +1,4 @@
-name: Push to GCR GitHub Action
+name: Build and Push to GCR - makedata.dockerfile
 on:
   push:
     branches:

--- a/.github/workflows/docker-train.yml
+++ b/.github/workflows/docker-train.yml
@@ -15,5 +15,5 @@ jobs:
           gcloud_service_key: ${{ secrets.GCR_KEY }}
           registry: gcr.io
           project_id: mlops-337909
-          image_name: make_data
+          image_name: train
           dockerfile: docker/train.dockerfile

--- a/.github/workflows/docker-train.yml
+++ b/.github/workflows/docker-train.yml
@@ -1,0 +1,19 @@
+name: Build and Push to GCR - train.dockerfile
+on:
+  push:
+    branches:
+        - main
+        - develop
+jobs:
+  build-and-push-to-gcr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: google-github-actions/setup-gcloud@master
+      - uses: RafikFarhad/push-to-gcr-github-action@v4
+        with:
+          gcloud_service_key: ${{ secrets.GCR_KEY }}
+          registry: gcr.io
+          project_id: mlops-337909
+          image_name: make_data
+          dockerfile: docker/train.dockerfile

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -28,10 +28,10 @@ point on the checklist for the exam.
 - [ ] Write unit tests related to the data part of your code
 - [ ] Write unit tests related to model construction
 - [ ] Calculate the coverage.
-- [ ] Get some continuous integration running on the github repository
-- [ ] (optional) Create a new project on `gcp` and invite all group members to it
+- [x] Get some continuous integration running on the github repository
+- [x] (optional) Create a new project on `gcp` and invite all group members to it
 - [ ] Create a data storage on `gcp` for you data
-- [ ] Create a trigger workflow for automatically building your docker images
+- [x] Create a trigger workflow for automatically building your docker images
 - [ ] Get your model training on `gcp`
 - [ ] Play around with distributed data loading
 - [ ] (optional) Play around with distributed model training


### PR DESCRIPTION
This PR enables two workflows using Github Actions, for building and pushing Docker images to Google Cloud Registry.

The docker images included are:
* make_data
* train

One attempt has been completed correctly:
https://github.com/peterampazzo/dtu-02476/runs/4845243479?check_suite_focus=true

The two workflows are executed at every push on the branch `main` and `develop`.
Credentials has been created and configured following [this guide](http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run). 