### PR TITLE
Google Cloud - Push data to bucket

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,6 @@
 [core]
-    remote = storage
-['remote "storage"']
+    remote = gcloud
+['remote "gdrive"']
     url = gdrive://1QdmKDG_F3U7sko3Bn800LeXpOf7lmvIE
+['remote "gcloud"']
+    url = gs://dtumlopsgroup/


### PR DESCRIPTION
- [x] A GCP project has been created
- [ ] All the team has access
- [x] Pushed data folder to a Bucket
- [ ] How to mount a bucket from a Docker image running on GCP

**Details**:
The bucket is available as: `gs://dtumlopsgroup/`.

We skipped using DVC since for running the code we need the data as it is -- to keep time load short we pushed the data as it is by running on command line: `gsutil -m cp -r data/ gs://dtumlopsgroup/`.